### PR TITLE
mention prefix and ignore bots

### DIFF
--- a/DiscordPets.py
+++ b/DiscordPets.py
@@ -35,7 +35,7 @@ class DiscordPets(commands.Bot):
     def __init__(self, **kwargs):
         super().__init__(
             description=kwargs.pop("description"),
-            command_prefix=config.prefix,
+            command_prefix=commands.when_mentioned_or(config.prefix),
             game=discord.Game(name=f"{config.prefix}help")
         )
 
@@ -45,8 +45,8 @@ class DiscordPets(commands.Bot):
         self.loop.create_task(self.load_all_extensions())
 
     async def on_message(self, message):
-        # Stop certain users from using the bot
-        if message.author.id in self.blocked:
+        # Stop certain users and bots from using the bot
+        if message.author.bot or message.author.id in self.blocked:
             return
             
         await self.process_commands(message)


### PR DESCRIPTION
Bot prefix is now "dp!" or a mention and messages from bot users are ignored.
This is to conform with the rules for bot certification on discordbots.org.
Once more pets are added and I'm confident that the bot will run without major issues, I'll apply.